### PR TITLE
Add array type to constant list

### DIFF
--- a/src/spec/Type.php
+++ b/src/spec/Type.php
@@ -20,4 +20,5 @@ class Type
     const STRING = 'string';
     const BOOLEAN = 'boolean';
     const OBJECT = 'object';
+    const ARRAY = 'array';
 }


### PR DESCRIPTION
I hope it's forgotten in referenced doc, but it really used and coiuld be found here

https://swagger.io/docs/specification/data-models/data-types/