### PR TITLE
Fix resolving recursive references

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,13 +194,11 @@ $openapi->resolveReferences(
 );
 ```
 
-> **Note:** Resolving references currently does not deal with references in referenced files, you have to call it multiple times to resolve these.
-
 ### Validation
 
 The library provides simple validation operations, that check basic OpenAPI spec requirements.
 This is the same as "structural errors found while reading the API Description file" from the CLI tool.
-This validation does not include checking against the OpenAPI v3.0 JSON schema.
+This validation does not include checking against the OpenAPI v3.0 JSON schema, this is only implemented in the CLI.
 
 ```
 // return `true` in case no errors have been found, `false` in case of errors.

--- a/src/spec/Operation.php
+++ b/src/spec/Operation.php
@@ -21,7 +21,7 @@ use cebe\openapi\SpecBaseObject;
  * @property string $operationId
  * @property Parameter[]|Reference[] $parameters
  * @property RequestBody|Reference|null $requestBody
- * @property Responses|null $responses
+ * @property Responses|Response[]|null $responses
  * @property Callback[]|Reference[] $callbacks
  * @property bool $deprecated
  * @property SecurityRequirement[] $security

--- a/src/spec/Responses.php
+++ b/src/spec/Responses.php
@@ -239,7 +239,11 @@ class Responses implements SpecObjectInterface, DocumentContextInterface, ArrayA
     {
         foreach ($this->_responses as $key => $response) {
             if ($response instanceof Reference) {
-                $this->_responses[$key] = $response->resolve($context);
+                $referencedObject = $response->resolve($context);
+                $this->_responses[$key] = $referencedObject;
+                if (!$referencedObject instanceof Reference && $referencedObject !== null) {
+                    $referencedObject->resolveReferences();
+                }
             } else {
                 $response->resolveReferences($context);
             }

--- a/tests/spec/data/reference/paths/pets.json
+++ b/tests/spec/data/reference/paths/pets.json
@@ -1,0 +1,14 @@
+{
+  "get": {
+    "responses": {
+      "200": {
+        "description": "return a pet",
+        "content": {
+          "application/json": {
+            "schema": {"$ref":  "../subdir/Pet.yaml"}
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/spec/data/reference/subdir.yaml
+++ b/tests/spec/data/reference/subdir.yaml
@@ -1,0 +1,18 @@
+openapi: 3.0.0
+info:
+  title: Link Example
+  version: 1.0.0
+components:
+  schemas:
+    Pet:
+      $ref: 'subdir/Pet.yaml'
+    Dog:
+      $ref: 'subdir/Dog.yaml'
+paths:
+  '/pet':
+    get:
+      responses:
+        200:
+          description: return a pet
+  '/pets':
+    "$ref": "paths/pets.json"

--- a/tests/spec/data/reference/subdir/Dog.yaml
+++ b/tests/spec/data/reference/subdir/Dog.yaml
@@ -1,0 +1,6 @@
+type: object
+properties:
+  name:
+    type: string
+  food:
+    $ref: '../Food.yaml'

--- a/tests/spec/data/reference/subdir/Pet.yaml
+++ b/tests/spec/data/reference/subdir/Pet.yaml
@@ -1,0 +1,6 @@
+type: object
+description: "A Pet"
+properties:
+  id:
+    type: integer
+    format: int64


### PR DESCRIPTION
- fix a bug with resolving recursive references when subdirectories are involved
  fixes #32
- overall improvement of resolving references
- one call to resolveReferences() is now sufficient to resolve all
  reference levels (only loops are detected and stay reference objects)