### PR TITLE
Add file path output

### DIFF
--- a/bin/php-openapi
+++ b/bin/php-openapi
@@ -123,7 +123,11 @@ switch ($command) {
         }
 
         if (!empty($errors)) {
-            print_formatted("\BErrors found while reading the API Description:\C\n", STDERR);
+            if ($inputFile === null) {
+                print_formatted("\BErrors found while reading the API description from STDIN:\C\n", STDERR);
+            } else {
+                print_formatted("\BErrors found while reading the API description from {$inputFile}:\C\n", STDERR);
+            }
             foreach ($errors as $error) {
                 if (($openPos = strpos($error, '[')) !== false && ($closePos = strpos($error, ']')) !== false && $openPos < $closePos) {
                     $error = escape_formatted(substr($error, 0, $openPos + 1)) . '\Y'


### PR DESCRIPTION
Hello,
i am using this script in an automated shell script, so i cant see what input file is used.
So i added the path to the error output.
I thought it would be also nice to be able to click on the path and get to the input file, because of this i output the realpath.
If needed i can disable this by default and add an option to the script.