### PR TITLE
Fix bug with referencing non-object types

### DIFF
--- a/src/SpecBaseObject.php
+++ b/src/SpecBaseObject.php
@@ -73,31 +73,30 @@ abstract class SpecBaseObject implements SpecObjectInterface, DocumentContextInt
                     $this->_errors[] = "property '$property' must be array, but " . gettype($data[$property]) . " given.";
                     continue;
                 }
-                if (isset($data[$property]['$ref'])) {
-                    $this->_properties[$property] = new Reference($data[$property], null);
-                    unset($data[$property]);
-                    continue;
-                }
                 switch (\count($type)) {
                     case 1:
-                        // array
-                        $this->_properties[$property] = [];
-                        foreach ($data[$property] as $item) {
-                            if ($type[0] === Type::STRING) {
-                                if (!is_string($item)) {
-                                    $this->_errors[] = "property '$property' must be array of strings, but array has " . gettype($item) . " element.";
-                                }
-                                $this->_properties[$property][] = $item;
-                            } elseif (Type::isScalar($type[0])) {
-                                $this->_properties[$property][] = $item;
-                            } elseif ($type[0] === Type::ANY) {
-                                if (is_array($item) && isset($item['$ref'])) {
-                                    $this->_properties[$property][] = new Reference($item, null);
-                                } else {
+                        if (isset($data[$property]['$ref'])) {
+                            $this->_properties[$property] = new Reference($data[$property], null);
+                        } else {
+                            // array
+                            $this->_properties[$property] = [];
+                            foreach ($data[$property] as $item) {
+                                if ($type[0] === Type::STRING) {
+                                    if (!is_string($item)) {
+                                        $this->_errors[] = "property '$property' must be array of strings, but array has " . gettype($item) . " element.";
+                                    }
                                     $this->_properties[$property][] = $item;
+                                } elseif (Type::isScalar($type[0])) {
+                                    $this->_properties[$property][] = $item;
+                                } elseif ($type[0] === Type::ANY) {
+                                    if (is_array($item) && isset($item['$ref'])) {
+                                        $this->_properties[$property][] = new Reference($item, null);
+                                    } else {
+                                        $this->_properties[$property][] = $item;
+                                    }
+                                } else {
+                                    $this->_properties[$property][] = $this->instantiate($type[0], $item);
                                 }
-                            } else {
-                                $this->_properties[$property][] = $this->instantiate($type[0], $item);
                             }
                         }
                         break;

--- a/src/SpecBaseObject.php
+++ b/src/SpecBaseObject.php
@@ -73,6 +73,11 @@ abstract class SpecBaseObject implements SpecObjectInterface, DocumentContextInt
                     $this->_errors[] = "property '$property' must be array, but " . gettype($data[$property]) . " given.";
                     continue;
                 }
+                if (isset($data[$property]['$ref'])) {
+                    $this->_properties[$property] = new Reference($data[$property], null);
+                    unset($data[$property]);
+                    continue;
+                }
                 switch (\count($type)) {
                     case 1:
                         // array
@@ -83,8 +88,14 @@ abstract class SpecBaseObject implements SpecObjectInterface, DocumentContextInt
                                     $this->_errors[] = "property '$property' must be array of strings, but array has " . gettype($item) . " element.";
                                 }
                                 $this->_properties[$property][] = $item;
-                            } elseif ($type[0] === Type::ANY || Type::isScalar($type[0])) {
+                            } elseif (Type::isScalar($type[0])) {
                                 $this->_properties[$property][] = $item;
+                            } elseif ($type[0] === Type::ANY) {
+                                if (is_array($item) && isset($item['$ref'])) {
+                                    $this->_properties[$property][] = new Reference($item, null);
+                                } else {
+                                    $this->_properties[$property][] = $item;
+                                }
                             } else {
                                 $this->_properties[$property][] = $this->instantiate($type[0], $item);
                             }
@@ -110,8 +121,14 @@ abstract class SpecBaseObject implements SpecObjectInterface, DocumentContextInt
                         }
                         break;
                 }
-            } elseif ($type === Type::ANY || Type::isScalar($type)) {
+            } elseif (Type::isScalar($type)) {
                 $this->_properties[$property] = $data[$property];
+            } elseif ($type === Type::ANY) {
+                if (is_array($data[$property]) && isset($data[$property]['$ref'])) {
+                    $this->_properties[$property] = new Reference($data[$property], null);
+                } else {
+                    $this->_properties[$property] = $data[$property];
+                }
             } else {
                 $this->_properties[$property] = $this->instantiate($type, $data[$property]);
             }
@@ -353,7 +370,7 @@ abstract class SpecBaseObject implements SpecObjectInterface, DocumentContextInt
             if ($value instanceof Reference) {
                 $referencedObject = $value->resolve($context);
                 $this->_properties[$property] = $referencedObject;
-                if (!$referencedObject instanceof Reference && $referencedObject !== null) {
+                if (!$referencedObject instanceof Reference && $referencedObject instanceof SpecObjectInterface) {
                     $referencedObject->resolveReferences();
                 }
             } elseif ($value instanceof SpecObjectInterface) {
@@ -363,7 +380,7 @@ abstract class SpecBaseObject implements SpecObjectInterface, DocumentContextInt
                     if ($item instanceof Reference) {
                         $referencedObject = $item->resolve($context);
                         $this->_properties[$property][$k] = $referencedObject;
-                        if (!$referencedObject instanceof Reference && $referencedObject !== null) {
+                        if (!$referencedObject instanceof Reference && $referencedObject instanceof SpecObjectInterface) {
                             $referencedObject->resolveReferences();
                         }
                     } elseif ($item instanceof SpecObjectInterface) {

--- a/src/spec/Reference.php
+++ b/src/spec/Reference.php
@@ -174,7 +174,9 @@ class Reference implements SpecObjectInterface, DocumentContextInterface
                     // TODO type error if resolved object does not match $this->_to ?
                     /** @var $referencedObject SpecObjectInterface */
                     $referencedObject = $jsonReference->getJsonPointer()->evaluate($baseSpec);
-                    $referencedObject->setReferenceContext($context);
+                    if ($referencedObject instanceof SpecObjectInterface) {
+                        $referencedObject->setReferenceContext($context);
+                    }
                     return $referencedObject;
                 } else {
                     // if current document was loaded via reference, it may be null,
@@ -196,10 +198,10 @@ class Reference implements SpecObjectInterface, DocumentContextInterface
             // transitive reference
             if (isset($referencedData['$ref'])) {
                 return (new Reference($referencedData, $this->_to))->resolve(new ReferenceContext(null, $file));
-            } else {
-                /** @var $referencedObject SpecObjectInterface */
-                $referencedObject = new $this->_to($referencedData);
             }
+            /** @var $referencedObject SpecObjectInterface|array */
+            $referencedObject = $this->_to !== null ? new $this->_to($referencedData) : $referencedData;
+
             if ($jsonReference->getJsonPointer()->getPointer() === '') {
                 $newContext = new ReferenceContext($referencedObject, $file);
                 if ($referencedObject instanceof DocumentContextInterface) {
@@ -212,7 +214,9 @@ class Reference implements SpecObjectInterface, DocumentContextInterface
                 $newContext = new ReferenceContext(null, $file);
             }
             $newContext->throwException = $context->throwException;
-            $referencedObject->setReferenceContext($newContext);
+            if ($referencedObject instanceof SpecObjectInterface) {
+                $referencedObject->setReferenceContext($newContext);
+            }
 
             return $referencedObject;
         } catch (NonexistentJsonPointerReferenceException $e) {

--- a/tests/spec/OpenApiTest.php
+++ b/tests/spec/OpenApiTest.php
@@ -171,7 +171,10 @@ class OpenApiTest extends \PHPUnit\Framework\TestCase
             $nexmoExamples
         );
         foreach($all as $path) {
-            yield [substr($path, strlen(__DIR__ . '/../../vendor/')), basename($path)];
+            yield [
+                substr($path, strlen(__DIR__ . '/../../vendor/')),
+                basename(dirname($path, 2)) . DIRECTORY_SEPARATOR . basename(dirname($path, 1)) . DIRECTORY_SEPARATOR . basename($path)
+            ];
         }
     }
 

--- a/tests/spec/data/reference/definitions.yaml
+++ b/tests/spec/data/reference/definitions.yaml
@@ -11,3 +11,8 @@ Dog:
       type: string
     food:
       $ref: 'Food.yaml'
+    typeD:
+      type: string
+      enum:
+        - "Four"
+        - "Five"


### PR DESCRIPTION
a reference to an array was crashing with an invalid function call.
Proper instanceof check has been added in Reference.

also creating references in non-object types and Type::ANY is working
correctly now.

fixes #47