### PR TITLE
Adds extra validation tests for Parameters

### DIFF
--- a/src/spec/Parameter.php
+++ b/src/spec/Parameter.php
@@ -117,7 +117,7 @@ class Parameter extends SpecBaseObject
         if (!empty($this->content) && !empty($this->schema)) {
             $this->addError('A Parameter Object MUST contain either a schema property, or a content property, but not both.');
         }
-        if(!empty($this->content) && count($this->content)!==1) {
+        if (! empty($this->content) && count($this->content) !== 1) {
             $this->addError('A Parameter Object MUST with Content property must have A SINGLE content type.');
         }
 
@@ -127,7 +127,7 @@ class Parameter extends SpecBaseObject
             'header' => ['simple'],
             'cookie' => ['form'],
         ];
-        if(!in_array($this->style, $supportedSerializationStyles[$this->in])) {
+        if (! in_array($this->style, $supportedSerializationStyles[$this->in])) {
             $this->addError('A Parameter Object DOES NOT support this serialization style.');
         }
     }

--- a/src/spec/Parameter.php
+++ b/src/spec/Parameter.php
@@ -117,6 +117,9 @@ class Parameter extends SpecBaseObject
         if (!empty($this->content) && !empty($this->schema)) {
             $this->addError('A Parameter Object MUST contain either a schema property, or a content property, but not both.');
         }
+        if(!empty($this->content) && count($this->content)!==1) {
+            $this->addError('A Parameter Object MUST with Content property must have A SINGLE content type.');
+        }
 
         $supportedSerializationStyles = [
             'path' => ['simple', 'label', 'matrix'],

--- a/src/spec/Parameter.php
+++ b/src/spec/Parameter.php
@@ -127,7 +127,7 @@ class Parameter extends SpecBaseObject
             'header' => ['simple'],
             'cookie' => ['form'],
         ];
-        if (! in_array($this->style, $supportedSerializationStyles[$this->in])) {
+        if (isset($supportedSerializationStyles[$this->in]) && !in_array($this->style, $supportedSerializationStyles[$this->in])) {
             $this->addError('A Parameter Object DOES NOT support this serialization style.');
         }
     }

--- a/src/spec/Parameter.php
+++ b/src/spec/Parameter.php
@@ -115,7 +115,17 @@ class Parameter extends SpecBaseObject
             }
         }
         if (!empty($this->content) && !empty($this->schema)) {
-            $this->addError("A Parameter Object MUST contain either a schema property, or a content property, but not both. ");
+            $this->addError('A Parameter Object MUST contain either a schema property, or a content property, but not both.');
+        }
+
+        $supportedSerializationStyles = [
+            'path' => ['simple', 'label', 'matrix'],
+            'query' => ['form', 'spaceDelimited', 'pipeDelimited', 'deepObject'],
+            'header' => ['simple'],
+            'cookie' => ['form'],
+        ];
+        if(!in_array($this->style, $supportedSerializationStyles[$this->in])) {
+            $this->addError('A Parameter Object DOES NOT support this serialization style.');
         }
     }
 }

--- a/src/spec/Parameter.php
+++ b/src/spec/Parameter.php
@@ -117,7 +117,7 @@ class Parameter extends SpecBaseObject
         if (!empty($this->content) && !empty($this->schema)) {
             $this->addError('A Parameter Object MUST contain either a schema property, or a content property, but not both.');
         }
-        if (! empty($this->content) && count($this->content) !== 1) {
+        if (!empty($this->content) && count($this->content) !== 1) {
             $this->addError('A Parameter Object with Content property MUST have A SINGLE content type.');
         }
 

--- a/src/spec/Parameter.php
+++ b/src/spec/Parameter.php
@@ -118,7 +118,7 @@ class Parameter extends SpecBaseObject
             $this->addError('A Parameter Object MUST contain either a schema property, or a content property, but not both.');
         }
         if (! empty($this->content) && count($this->content) !== 1) {
-            $this->addError('A Parameter Object MUST with Content property must have A SINGLE content type.');
+            $this->addError('A Parameter Object with Content property MUST have A SINGLE content type.');
         }
 
         $supportedSerializationStyles = [

--- a/tests/spec/ParameterTest.php
+++ b/tests/spec/ParameterTest.php
@@ -169,6 +169,28 @@ YAML
         $this->assertFalse($result);
     }
 
+    public function testItValidatesContentCanHaveOnlySingleKey()
+    {
+        /** @var $parameter Parameter */
+        $parameter = Reader::readFromYaml(<<<'YAML'
+name: token
+in: cookie
+content:
+  application/json:
+    schema:
+      type: object
+  application/xml:
+    schema:
+      type: object
+YAML
+            , Parameter::class);
+
+        $result = $parameter->validate();
+        $this->assertEquals(['A Parameter Object MUST with Content property must have A SINGLE content type.'], $parameter->getErrors());
+        $this->assertFalse($result);
+    }
+
+
     public function testItValidatesSupportedSerializationStyles()
     {
         // 1. Prepare test inputs

--- a/tests/spec/ParameterTest.php
+++ b/tests/spec/ParameterTest.php
@@ -186,7 +186,7 @@ YAML
             , Parameter::class);
 
         $result = $parameter->validate();
-        $this->assertEquals(['A Parameter Object MUST with Content property must have A SINGLE content type.'], $parameter->getErrors());
+        $this->assertEquals(['A Parameter Object with Content property MUST have A SINGLE content type.'], $parameter->getErrors());
         $this->assertFalse($result);
     }
 


### PR DESCRIPTION
Why this PR is here.
I am working on validation for incoming HTTP requests, containing serialized parameters: https://github.com/thephpleague/openapi-psr7-validator/issues/2

It looks like this package should be responsible for validating serialization styles defined in the specifications. It should prevent wrong styles chosen. So the abovementioned package can safely rely on the specification to use a correct style for deserialization.

New tests in `ParameterTest.php`:
- `testItValidatesSchemaAndContentCombination` checks that both "content" and "schema" cannot be present
- `testItValidatesSupportedSerializationStyles` checks that only certain serialization styles supported for each Parameter type.
- `testItValidatesContentCanHaveOnlySingleKey` enforces this rule:
![image](https://user-images.githubusercontent.com/10206110/72045704-986fa600-32d8-11ea-9cf8-366d7d0b6aa1.png)
