### PR TITLE
Update openapi-psr7-validator reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ do awesome work:
 
 - [cebe/yii2-openapi](https://github.com/cebe/yii2-openapi) Code Generator for REST API from OpenAPI 3 Descriptions, includes fake data generator.
 - [cebe/yii2-app-api](https://github.com/cebe/yii2-app-api) Yii framework application template for developing API-first applications.
-- [lezhnev74/openapi-psr7-validator](https://github.com/lezhnev74/openapi-psr7-validator) validates PSR-7 messages (HTTP request/response) against OpenAPI descriptions.
+- [league/openapi-psr7-validator](https://github.com/thephpleague/openapi-psr7-validator) validates PSR-7 messages (HTTP request/response) against OpenAPI descriptions.
 - ... ([add yours](https://github.com/cebe/php-openapi/edit/master/README.md#L24))
 
 ## Usage


### PR DESCRIPTION
Per [its README](https://github.com/lezhnev74/openapi-psr7-validator#notice---the-package-has-been-contributed-to-the-php-league), `lezhnev74/openapi-psr7-validator` has been contributed to the PHP League and is now being developed under that organization's namespace. This PR updates a reference to the old package in this project's README to point to the new package.