### PR TITLE
Add support for Symfony/YAML 4.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 	"require": {
 		"php": ">=7.1.0",
 		"ext-json": "*",
-		"symfony/yaml": "^3.0 | ~4.0.0 | ~4.1.0 | ~4.2.0 | ~4.3.0 | ^5.0",
+		"symfony/yaml": "^3.0 | ~4.0.0 | ~4.1.0 | ~4.2.0 | ~4.3.0 | ~4.4.0 | ^5.0",
 		"justinrainbow/json-schema": "^5.0"
 	},
 	"require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 	"require": {
 		"php": ">=7.1.0",
 		"ext-json": "*",
-		"symfony/yaml": "^3.0 | ~4.0.0 | ~4.1.0 | ~4.2.0 | ~4.3.0 | ~4.4.0 | ^5.0",
+		"symfony/yaml": "^3.0 | ^4.0 | ^5.0",
 		"justinrainbow/json-schema": "^5.0"
 	},
 	"require-dev": {


### PR DESCRIPTION
Add support for Symfony/YAML 4.4, this is a transition version to 5. In 4.4 you can fix/remove deprecated code before migrate to version 5