### PR TITLE
Unresolved reference while instantiating Encoding

### DIFF
--- a/src/spec/MediaType.php
+++ b/src/spec/MediaType.php
@@ -53,7 +53,13 @@ class MediaType extends SpecBaseObject
                 if ($encodingData instanceof Encoding) {
                     $encoding[$property] = $encodingData;
                 } elseif (is_array($encodingData)) {
-                    $encoding[$property] = new Encoding($encodingData, $this->schema->properties[$property] ?? null);
+                    // Don't pass the schema if it's still an unresolved reference.
+                    if (this->schema->properties[$property] instanceof Reference) {
+                        $encoding[$property] = new Encoding($encodingData);
+                    }
+                    else {
+                        $encoding[$property] = new Encoding($encodingData, $this->schema->properties[$property] ?? null);
+                    }
                 } else {
                     $givenType = gettype($encodingData);
                     if ($givenType === 'object') {

--- a/tests/spec/OpenApiTest.php
+++ b/tests/spec/OpenApiTest.php
@@ -239,4 +239,54 @@ class OpenApiTest extends \PHPUnit\Framework\TestCase
         }
 
     }
+
+    public function testUnresolvedReferencesInEncoding($config, $expectedException)
+    {
+        $yaml = Yaml::parse(<<<'YAML'
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Encoding test
+paths:
+  /pets:
+    post:
+      summary: Create a pet
+      operationId: createPets
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                pet:
+                  $ref: '#/components/schemas/Pet'
+                petImage:
+                  type: string
+                  format: binary
+            encoding:
+              pet:
+                contentType: application/json
+              petImage:
+                contentType: image/*
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses:
+        '201':
+          description: Null response
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string
+YAML
+);
+        $openapi = new OpenApi($yaml);
+        $result = $openapi->validate();
+
+        $this->assertEquals([], $openapi->getErrors());
+        $this->assertTrue($result);
+    }
 }


### PR DESCRIPTION
If there's a `$ref` within a `multipart/form-data` `requestBody`, the `Encoding` will be instantiated with a `Reference` object instead of a `Schema` object as expected resulting in a `TypeErrorException`.

To reproduce, just parse the following OpenAPI schema:
```yaml
openapi: "3.0.0"
info:
  version: 1.0.0
  title: Multipart demo
paths:
  /pets:
    post:
      summary: Create a pet
      operationId: createPets
      tags:
        - pets
      requestBody:
        content:
          multipart/form-data:
            schema:
              type: object
              properties:
                pet:
                  $ref: '#/components/schemas/Pet'
                petImage:
                  type: string
                  format: binary
            encoding:
              pet:
                contentType: application/json
              petImage:
                contentType: image/*
          application/json:
            schema:
              $ref: '#/components/schemas/Pet'
        description: The pet to be created
        required: true
      responses:
        '201':
          description: Null response

components:
  schemas:
    Pet:
      type: object
      properties:
        id:
          type: integer
          format: int64
        name:
          type: string
```

Since this parameter is only ever used to guess the default encoding type of a property if and when it is not explicitly defined, I propose to skip the schema parameter altogether if during instantiation it is still an unresolved reference (otherwise we would have to pre-resolve references during instantiation leading to all other kinds of mishaps and a very substantial rewrite of the whole project).

https://github.com/cebe/php-openapi/blob/aafedb56ed8b860ce83b51b81bc1c902b77d8ecb/src/spec/MediaType.php#L56-L62