### PR TITLE
PHP8 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /node_modules
 
 /.php_cs.cache
+
+php-cs-fixer.phar

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
     - php: '7.4'
       env: YAML=^5.0
     - php: nightly
-      env: YAML=~4.3.0
+      env: YAML=~4.4.0
     # windows tests
     # https://travis-ci.community/t/where-to-contribute-php-support-for-windows/304
     - os: windows
@@ -57,6 +57,6 @@ script:
   - make lint
   - make stan
   - make test
-  - if [[ $TRAVIS_PHP_VERSION = "7.3" || $TRAVIS_PHP_VERSION = "nightly" ]]; then true; else make check-style; fi
+  - make check-style
   - make coverage
 

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ endif
 
 all:
 
-check-style:
-	vendor/bin/php-cs-fixer fix src/ --diff --dry-run
+check-style: php-cs-fixer.phar
+	PHP_CS_FIXER_IGNORE_ENV=1 ./php-cs-fixer.phar fix src/ --diff --dry-run
 
 fix-style:
 	vendor/bin/indent --tabs composer.json
@@ -42,6 +42,8 @@ schemas/openapi-v3.0.json: vendor/oai/openapi-specification/schemas/v3.0/schema.
 schemas/openapi-v3.0.yaml: vendor/oai/openapi-specification/schemas/v3.0/schema.yaml
 	cp $< $@
 
+php-cs-fixer.phar:
+	wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.16.7/php-cs-fixer.phar && chmod +x php-cs-fixer.phar
 
 # find spec classes that are not mentioned in tests with @covers yet
 coverage: .php-openapi-covA .php-openapi-covB

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,7 @@
 	},
 	"require-dev": {
 		"cebe/indent": "*",
-		"friendsofphp/php-cs-fixer": "~2.16.1",
-		"phpunit/phpunit": "^6.5",
+		"phpunit/phpunit": "^6.5 || ^7.5 || ^8.5 || ^9.4",
 
 		"oai/openapi-specification": "3.0.2",
 		"mermade/openapi3-examples": "1.0.0",

--- a/tests/ReaderTest.php
+++ b/tests/ReaderTest.php
@@ -112,7 +112,13 @@ YAML
         $openapi = \cebe\openapi\Reader::readFromYamlFile($openApiFile);
 
         $inlineYamlExample = $openapi->paths['/']->get->responses['200']->content['application/json']->example;
-        $this->assertInternalType('array', $inlineYamlExample);
+
+        if (method_exists($this, 'assertIsArray')) {
+            $this->assertIsArray($inlineYamlExample);
+        } else {
+            $this->assertInternalType('array', $inlineYamlExample);
+        }
+
         $expectedArray = json_decode(<<<JSON
 {
   "total": 2,

--- a/tests/spec/MediaTypeTest.php
+++ b/tests/spec/MediaTypeTest.php
@@ -46,7 +46,13 @@ YAML
         $this->assertTrue($result);
 
         $this->assertInstanceOf(Reference::class, $mediaType->schema);
-        $this->assertInternalType('array', $mediaType->examples);
+
+        if (method_exists($this, 'assertIsArray')) {
+            $this->assertIsArray($mediaType->examples);
+        } else {
+            $this->assertInternalType('array', $mediaType->examples);
+        }
+
         $this->assertCount(3, $mediaType->examples);
         $this->assertArrayHasKey('cat', $mediaType->examples);
         $this->assertArrayHasKey('dog', $mediaType->examples);

--- a/tests/spec/OpenApiTest.php
+++ b/tests/spec/OpenApiTest.php
@@ -52,7 +52,12 @@ class OpenApiTest extends \PHPUnit\Framework\TestCase
 
 
         // servers
-        $this->assertInternalType('array', $openapi->servers);
+        if (method_exists($this, 'assertIsArray')) {
+            $this->assertIsArray($openapi->servers);
+        } else {
+            $this->assertInternalType('array', $openapi->servers);
+        }
+
         $this->assertCount(1, $openapi->servers);
         foreach ($openapi->servers as $server) {
             $this->assertInstanceOf(\cebe\openapi\spec\Server::class, $server);


### PR DESCRIPTION
This PR:

- [x] Fixes #81 
- [x] Removes `php-cs-fixer` from composer.json and downloads phar on launch
- [x] Fixes deprecated PHPUnit methods