### PR TITLE
Fix PathItem::resolveReferences() for array fields

### DIFF
--- a/src/spec/PathItem.php
+++ b/src/spec/PathItem.php
@@ -174,7 +174,8 @@ class PathItem extends SpecBaseObject
                     foreach ($this->$attribute as $k => $item) {
                         if ($item instanceof Reference) {
                             $referencedObject = $item->resolve();
-                            $this->$attribute[$k] = $referencedObject;
+                            $this->$attribute =
+                              [ $k => $referencedObject ] + $this->$attribute;
                             if (!$referencedObject instanceof Reference && $referencedObject !== null) {
                                 $referencedObject->resolveReferences();
                             }


### PR DESCRIPTION
With the previous code `$this->$attribute[$k] = $referencedObject`, PHP issues `Notice: Indirect modification of overloaded property cebe\openapi\spec\PathItem::$parameters has no effect`.

The simplest fix I could think of is `$this->$attribute = [ $k => $referencedObject ] + $this->$attribute`.