### PR TITLE
Add exception in readFromJsonFile

### DIFF
--- a/src/Reader.php
+++ b/src/Reader.php
@@ -10,6 +10,7 @@ namespace cebe\openapi;
 use cebe\openapi\exceptions\IOException;
 use cebe\openapi\exceptions\TypeErrorException;
 use cebe\openapi\exceptions\UnresolvableReferenceException;
+use cebe\openapi\json\InvalidJsonPointerSyntaxException;
 use cebe\openapi\json\JsonPointer;
 use cebe\openapi\spec\OpenApi;
 use Symfony\Component\Yaml\Yaml;
@@ -69,6 +70,7 @@ class Reader
      * @throws TypeErrorException in case invalid spec data is supplied.
      * @throws UnresolvableReferenceException in case references could not be resolved.
      * @throws IOException when the file is not readable.
+     * @throws InvalidJsonPointerSyntaxException in case an invalid JSON pointer string is passed to the spec references.
      */
     public static function readFromJsonFile(string $fileName, string $baseType = OpenApi::class, $resolveReferences = true): SpecObjectInterface
     {


### PR DESCRIPTION
The InvalidJsonPointerSyntaxException can be thrown in
readFromJsonFile, users need to know it in order to catch it.