### PR TITLE
Add PHPStan Template

### DIFF
--- a/src/Reader.php
+++ b/src/Reader.php
@@ -22,6 +22,9 @@ class Reader
 {
     /**
      * Populate OpenAPI spec object from JSON data.
+     * @phpstan-template T of SpecObjectInterface
+     * @phpstan-param class-string<T> $baseType
+     * @phpstan-return T
      * @param string $json the JSON string to decode.
      * @param string $baseType the base Type to instantiate. This must be an instance of [[SpecObjectInterface]].
      * The default is [[OpenApi]] which is the base type of a OpenAPI specification file.
@@ -37,6 +40,9 @@ class Reader
 
     /**
      * Populate OpenAPI spec object from YAML data.
+     * @phpstan-template T of SpecObjectInterface
+     * @phpstan-param class-string<T> $baseType
+     * @phpstan-return T
      * @param string $yaml the YAML string to decode.
      * @param string $baseType the base Type to instantiate. This must be an instance of [[SpecObjectInterface]].
      * The default is [[OpenApi]] which is the base type of a OpenAPI specification file.
@@ -52,6 +58,9 @@ class Reader
 
     /**
      * Populate OpenAPI spec object from a JSON file.
+     * @phpstan-template T of SpecObjectInterface
+     * @phpstan-param class-string<T> $baseType
+     * @phpstan-return T
      * @param string $fileName the file name of the file to be read.
      * If `$resolveReferences` is true (the default), this should be an absolute URL, a `file://` URI or
      * an absolute path to allow resolving relative path references.
@@ -95,6 +104,9 @@ class Reader
 
     /**
      * Populate OpenAPI spec object from YAML file.
+     * @phpstan-template T of SpecObjectInterface
+     * @phpstan-param class-string<T> $baseType
+     * @phpstan-return T
      * @param string $fileName the file name of the file to be read.
      * If `$resolveReferences` is true (the default), this should be an absolute URL, a `file://` URI or
      * an absolute path to allow resolving relative path references.


### PR DESCRIPTION
Hi,

are you open for PHPStan specific Annotations? 
The following PR will fix following use case:

```php
$spec = cebe\openapi\Reader::readFromYamlFile($inputFile, cebe\openapi\spec\OpenApi::class);
// this is required because the method returns only a SpecObjectInterface as annotation
assert($spec instanceof cebe\openapi\spec\OpenApi);
```

With the `@phpstan-template` annotation, PHPStan knowns, that the second parameter defines the return type and the paramater must be a class string and an instanceof SpecObjectInterface.

This should help other people who uses PHPStan and your library. 

If you are fine with this, i will try to add more PHPStan specific type hints. But first i wanted to know if you would support that annotations. 