### PR TITLE
Fix OpenAPI v3.0 Schema Violation: Array value found, but an object is required

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,11 +24,13 @@ test:
 	php $(PHPARGS) $(XPHPARGS) vendor/bin/phpunit --verbose --colors=always $(TESTCASE)
 	php $(PHPARGS) $(XPHPARGS) bin/php-openapi validate tests/spec/data/recursion.json
 	php $(PHPARGS) $(XPHPARGS) bin/php-openapi validate tests/spec/data/recursion2.yaml
+	php $(PHPARGS) $(XPHPARGS) bin/php-openapi validate tests/spec/data/empty-maps.json
 
 lint:
 	php $(PHPARGS) $(XPHPARGS) bin/php-openapi validate tests/spec/data/reference/playlist.json
 	php $(PHPARGS) $(XPHPARGS) bin/php-openapi validate tests/spec/data/recursion.json
 	php $(PHPARGS) $(XPHPARGS) bin/php-openapi validate tests/spec/data/recursion2.yaml
+	php $(PHPARGS) $(XPHPARGS) bin/php-openapi validate tests/spec/data/empty-maps.json
 	node_modules/.bin/speccy lint tests/spec/data/reference/playlist.json
 	node_modules/.bin/speccy lint tests/spec/data/recursion.json
 

--- a/src/SpecBaseObject.php
+++ b/src/SpecBaseObject.php
@@ -191,14 +191,19 @@ abstract class SpecBaseObject implements SpecObjectInterface, DocumentContextInt
                 $data[$k] = $v->getSerializableData();
             } elseif (is_array($v)) {
                 $toObject = false;
-                $j = 0;
-                foreach ($v as $i => $d) {
-                    if ($j++ !== $i) {
-                        $toObject = true;
+                if (!empty($v)) {
+                    $j = 0;
+                    foreach ($v as $i => $d) {
+                        if ($j++ !== $i) {
+                            $toObject = true;
+                        }
+                        if ($d instanceof SpecObjectInterface) {
+                            $data[$k][$i] = $d->getSerializableData();
+                        }
                     }
-                    if ($d instanceof SpecObjectInterface) {
-                        $data[$k][$i] = $d->getSerializableData();
-                    }
+                } elseif (isset($this->attributes()[$k]) && is_array($this->attributes()[$k]) && 2 === count($this->attributes()[$k])) {
+                    // An empty Map, which is an empty array in PHP but needs to be an empty object in output.
+                    $toObject = true;
                 }
                 if ($toObject) {
                     $data[$k] = (object) $data[$k];

--- a/tests/spec/data/empty-maps.json
+++ b/tests/spec/data/empty-maps.json
@@ -1,0 +1,22 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "test",
+    "version": "1.0"
+  },
+  "paths": {
+    "/products": {
+      "description": "default",
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Products",
+            "headers": {},
+            "content": {},
+            "links": {}
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Hi there,


Thank you for your very useful tool, it's been really useful in our projects.

`bin/php-openapi validate` currently fails unexpectedly when validating a schema that specifies an empty value for a Map OpenAPI field.

For example, the minimal specification I've provided in c5ca5238d952d9f380507c1bd1401ce48bae1567 currently fails:

```
bin/php-openapi validate tests/spec/data/empty-maps.json
OpenAPI v3.0 schema violations:
- [paths./products.get.responses[200].headers] Array value found, but an object is required
- [paths./products.get.responses[200].content] Array value found, but an object is required
- [paths./products.get.responses[200].links] Array value found, but an object is required
```
Whereas that specification passes in various other validation tools such as https://apitools.dev/swagger-parser/online/ or https://www.jsonschemavalidator.net/.

This PR changes to the Serialization process so that empty Map Fields are correctly validated.

The example in this PR uses the [Response object](https://swagger.io/specification/#response-object), however, the fix should apply for any Map type fields.
