### PR TITLE
Add `symfony/yaml` 6.0.0 support

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-#        os: [ubuntu-latest, macos-latest, windows-latest]
+        # os: [ubuntu-latest, macos-latest, windows-latest]
         os: [ubuntu-latest]
         php: ['7.1', '7.2', '7.3', '7.4', '8.0']
         # max 4.4.16, see https://github.com/symfony/symfony/issues/39521
@@ -31,6 +31,9 @@ jobs:
           - php: '7.4'
             os: macos-latest
             yaml: '5.2.9'
+          - php: '8.0'
+            os: ubuntu-latest
+            yaml: '^6.0'
 
 
     runs-on: ${{ matrix.os }}
@@ -70,13 +73,13 @@ jobs:
         if: matrix.os != 'windows-latest'
         run: |
           make install
-          composer require symfony/yaml:"${YAML}" --prefer-dist --no-interaction --ansi
+          composer require symfony/yaml:"${YAML}" --prefer-dist --no-interaction --with-all-dependencies --ansi
 
       - name: Install dependencies (Windows)
         if: matrix.os == 'windows-latest'
         run: |
           composer install --prefer-dist --no-interaction --no-progress --ansi
-          composer require symfony/yaml:5.1.8 --prefer-dist --no-interaction --ansi
+          composer require symfony/yaml:5.1.8 --prefer-dist --no-interaction --with-all-dependencies --ansi
 
       - name: Validate test data
         if: matrix.os == 'ubuntu-latest'

--- a/composer.json
+++ b/composer.json
@@ -20,13 +20,12 @@
 	"require": {
 		"php": ">=7.1.0",
 		"ext-json": "*",
-		"symfony/yaml": "^3.4 | ^4.0 | ^5.0",
+		"symfony/yaml": "^3.4 || ^4.0 || ^5.0 || ^6.0",
 		"justinrainbow/json-schema": "^5.0"
 	},
 	"require-dev": {
 		"cebe/indent": "*",
 		"phpunit/phpunit": "^6.5 || ^7.5 || ^8.5 || ^9.4",
-
 		"oai/openapi-specification": "3.0.3",
 		"mermade/openapi3-examples": "1.0.0",
 		"apis-guru/openapi-directory": "1.0.0",


### PR DESCRIPTION
Symfony 6  released on [November 29, 2021 ](https://symfony.com/blog/symfony-6-0-0-released).

Also, updated Github Action config to include 6, ans use the latest 5.x version