### PR TITLE
Drop licence badge from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ It also provides a CLI tool for validating and converting OpenAPI 3.0.x Descript
 [![Latest Stable Version](https://poser.pugx.org/cebe/php-openapi/v/stable)](https://packagist.org/packages/cebe/php-openapi)
 [![Total Downloads](https://poser.pugx.org/cebe/php-openapi/downloads)](https://packagist.org/packages/cebe/php-openapi)
 [![Build Status](https://github.com/cebe/php-openapi/workflows/PHP%20Composer/badge.svg)](https://github.com/cebe/php-openapi/actions)
-[![License](https://poser.pugx.org/cebe/php-openapi/license)](https://packagist.org/packages/cebe/php-openapi)
 
 
 ## Install


### PR DESCRIPTION
Licence information is already natively displayed on Github and Packagist so there's no need for having a badge