### PR TITLE
Update pre-release openapi 3.1 schema to current in 31 branch

### DIFF
--- a/schemas/openapi-v3.1.json
+++ b/schemas/openapi-v3.1.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://spec.openapis.org/oas/3.1/schema/2021-03-02",
+  "$id": "https://spec.openapis.org/oas/3.1/schema/2021-09-28",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "properties": {
@@ -11,11 +11,15 @@
       "$ref": "#/$defs/info"
     },
     "jsonSchemaDialect": {
-      "$ref": "#/$defs/uri",
+      "type": "string",
+      "format": "uri",
       "default": "https://spec.openapis.org/oas/3.1/dialect/base"
     },
     "servers": {
-      "$ref": "#/$defs/server"
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/server"
+      }
     },
     "paths": {
       "$ref": "#/$defs/paths"
@@ -70,6 +74,7 @@
   "unevaluatedProperties": false,
   "$defs": {
     "info": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#info-object",
       "type": "object",
       "properties": {
         "title": {
@@ -102,6 +107,7 @@
       "unevaluatedProperties": false
     },
     "contact": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#contact-object",
       "type": "object",
       "properties": {
         "name": {
@@ -118,6 +124,7 @@
       "unevaluatedProperties": false
     },
     "license": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#license-object",
       "type": "object",
       "properties": {
         "name": {
@@ -127,7 +134,8 @@
           "type": "string"
         },
         "url": {
-          "$ref": "#/$defs/uri"
+          "type": "string",
+          "format": "uri"
         }
       },
       "required": [
@@ -149,10 +157,12 @@
       "unevaluatedProperties": false
     },
     "server": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#server-object",
       "type": "object",
       "properties": {
         "url": {
-          "$ref": "#/$defs/uri"
+          "type": "string",
+          "format": "uri-reference"
         },
         "description": {
           "type": "string"
@@ -171,6 +181,7 @@
       "unevaluatedProperties": false
     },
     "server-variable": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#server-variable-object",
       "type": "object",
       "properties": {
         "enum": {
@@ -183,7 +194,7 @@
         "default": {
           "type": "string"
         },
-        "descriptions": {
+        "description": {
           "type": "string"
         }
       },
@@ -194,6 +205,7 @@
       "unevaluatedProperties": false
     },
     "components": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#components-object",
       "type": "object",
       "properties": {
         "schemas": {
@@ -269,6 +281,7 @@
       "unevaluatedProperties": false
     },
     "paths": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#paths-object",
       "type": "object",
       "patternProperties": {
         "^/": {
@@ -279,6 +292,7 @@
       "unevaluatedProperties": false
     },
     "path-item": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#path-item-object",
       "type": "object",
       "properties": {
         "summary": {
@@ -301,7 +315,7 @@
         }
       },
       "patternProperties": {
-        "^(get|post|delete|options|head|patch|trace)$": {
+        "^(get|put|post|delete|options|head|patch|trace)$": {
           "$ref": "#/$defs/operation"
         }
       },
@@ -310,6 +324,7 @@
     },
     "path-item-or-reference": {
       "if": {
+        "type": "object",
         "required": [
           "$ref"
         ]
@@ -322,6 +337,7 @@
       }
     },
     "operation": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#operation-object",
       "type": "object",
       "properties": {
         "tags": {
@@ -381,13 +397,15 @@
       "unevaluatedProperties": false
     },
     "external-documentation": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#external-documentation-object",
       "type": "object",
       "properties": {
         "description": {
           "type": "string"
         },
         "url": {
-          "$ref": "#/$defs/uri"
+          "type": "string",
+          "format": "uri"
         }
       },
       "required": [
@@ -397,6 +415,7 @@
       "unevaluatedProperties": false
     },
     "parameter": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#parameter-object",
       "type": "object",
       "properties": {
         "name": {
@@ -429,10 +448,13 @@
           "$dynamicRef": "#meta"
         },
         "content": {
-          "$ref": "#/$defs/content"
+          "$ref": "#/$defs/content",
+          "minProperties": 1,
+          "maxProperties": 1
         }
       },
       "required": [
+        "name",
         "in"
       ],
       "oneOf": [
@@ -495,6 +517,9 @@
               },
               "then": {
                 "properties": {
+                  "name": {
+                    "pattern": "[^/#?]+$"
+                  },
                   "style": {
                     "default": "simple",
                     "enum": [
@@ -527,9 +552,7 @@
                 "properties": {
                   "style": {
                     "default": "simple",
-                    "enum": [
-                      "simple"
-                    ]
+                    "const": "simple"
                   }
                 }
               }
@@ -574,9 +597,7 @@
                 "properties": {
                   "style": {
                     "default": "form",
-                    "enum": [
-                      "form"
-                    ]
+                    "const": "form"
                   }
                 }
               }
@@ -615,6 +636,7 @@
     },
     "parameter-or-reference": {
       "if": {
+        "type": "object",
         "required": [
           "$ref"
         ]
@@ -627,6 +649,7 @@
       }
     },
     "request-body": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#request-body-object",
       "type": "object",
       "properties": {
         "description": {
@@ -648,6 +671,7 @@
     },
     "request-body-or-reference": {
       "if": {
+        "type": "object",
         "required": [
           "$ref"
         ]
@@ -660,6 +684,7 @@
       }
     },
     "content": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#fixed-fields-10",
       "type": "object",
       "additionalProperties": {
         "$ref": "#/$defs/media-type"
@@ -669,6 +694,7 @@
       }
     },
     "media-type": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#media-type-object",
       "type": "object",
       "properties": {
         "schema": {
@@ -692,6 +718,7 @@
       "unevaluatedProperties": false
     },
     "encoding": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#encoding-object",
       "type": "object",
       "properties": {
         "contentType": {
@@ -760,6 +787,7 @@
       }
     },
     "responses": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#responses-object",
       "type": "object",
       "properties": {
         "default": {
@@ -767,7 +795,7 @@
         }
       },
       "patternProperties": {
-        "^[1-5][0-9X]{2}$": {
+        "^[1-5](?:[0-9]{2}|XX)$": {
           "$ref": "#/$defs/response-or-reference"
         }
       },
@@ -775,6 +803,7 @@
       "unevaluatedProperties": false
     },
     "response": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#response-object",
       "type": "object",
       "properties": {
         "description": {
@@ -804,6 +833,7 @@
     },
     "response-or-reference": {
       "if": {
+        "type": "object",
         "required": [
           "$ref"
         ]
@@ -816,6 +846,7 @@
       }
     },
     "callbacks": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#callback-object",
       "type": "object",
       "$ref": "#/$defs/specification-extensions",
       "additionalProperties": {
@@ -824,6 +855,7 @@
     },
     "callbacks-or-reference": {
       "if": {
+        "type": "object",
         "required": [
           "$ref"
         ]
@@ -836,6 +868,7 @@
       }
     },
     "example": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#example-object",
       "type": "object",
       "properties": {
         "summary": {
@@ -846,7 +879,8 @@
         },
         "value": true,
         "externalValue": {
-          "$ref": "#/$defs/uri"
+          "type": "string",
+          "format": "uri"
         }
       },
       "$ref": "#/$defs/specification-extensions",
@@ -854,6 +888,7 @@
     },
     "example-or-reference": {
       "if": {
+        "type": "object",
         "required": [
           "$ref"
         ]
@@ -866,10 +901,12 @@
       }
     },
     "link": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#link-object",
       "type": "object",
       "properties": {
         "operationRef": {
-          "$ref": "#/$defs/uri"
+          "type": "string",
+          "format": "uri-reference"
         },
         "operationId": true,
         "parameters": {
@@ -900,6 +937,7 @@
     },
     "link-or-reference": {
       "if": {
+        "type": "object",
         "required": [
           "$ref"
         ]
@@ -912,6 +950,7 @@
       }
     },
     "header": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#header-object",
       "type": "object",
       "properties": {
         "description": {
@@ -925,40 +964,40 @@
           "default": false,
           "type": "boolean"
         },
-        "allowEmptyValue": {
-          "default": false,
-          "type": "boolean"
+        "schema": {
+          "$dynamicRef": "#meta"
+        },
+        "content": {
+          "$ref": "#/$defs/content",
+          "minProperties": 1,
+          "maxProperties": 1
         }
       },
+      "oneOf": [
+        {
+          "required": [
+            "schema"
+          ]
+        },
+        {
+          "required": [
+            "content"
+          ]
+        }
+      ],
       "dependentSchemas": {
         "schema": {
           "properties": {
             "style": {
               "default": "simple",
-              "enum": [
-                "simple"
-              ]
+              "const": "simple"
             },
             "explode": {
               "default": false,
               "type": "boolean"
-            },
-            "allowReserved": {
-              "default": false,
-              "type": "boolean"
-            },
-            "schema": {
-              "$dynamicRef": "#meta"
             }
           },
           "$ref": "#/$defs/examples"
-        },
-        "content": {
-          "properties": {
-            "content": {
-              "$ref": "#/$defs/content"
-            }
-          }
         }
       },
       "$ref": "#/$defs/specification-extensions",
@@ -966,6 +1005,7 @@
     },
     "header-or-reference": {
       "if": {
+        "type": "object",
         "required": [
           "$ref"
         ]
@@ -978,6 +1018,7 @@
       }
     },
     "tag": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#tag-object",
       "type": "object",
       "properties": {
         "name": {
@@ -997,10 +1038,12 @@
       "unevaluatedProperties": false
     },
     "reference": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#reference-object",
       "type": "object",
       "properties": {
         "$ref": {
-          "$ref": "#/$defs/uri"
+          "type": "string",
+          "format": "uri-reference"
         },
         "summary": {
           "type": "string"
@@ -1012,6 +1055,7 @@
       "unevaluatedProperties": false
     },
     "schema": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#schema-object",
       "$dynamicAnchor": "meta",
       "type": [
         "object",
@@ -1019,6 +1063,7 @@
       ]
     },
     "security-scheme": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#security-scheme-object",
       "type": "object",
       "properties": {
         "type": {
@@ -1118,7 +1163,8 @@
                 "const": "http"
               },
               "scheme": {
-                "const": "bearer"
+                "type": "string",
+                "pattern": "^[Bb][Ee][Aa][Rr][Ee][Rr]$"
               }
             },
             "required": [
@@ -1131,10 +1177,7 @@
               "bearerFormat": {
                 "type": "string"
               }
-            },
-            "required": [
-              "scheme"
-            ]
+            }
           }
         },
         "type-oauth2": {
@@ -1173,7 +1216,8 @@
           "then": {
             "properties": {
               "openIdConnectUrl": {
-                "$ref": "#/$defs/uri"
+                "type": "string",
+                "format": "uri"
               }
             },
             "required": [
@@ -1185,6 +1229,7 @@
     },
     "security-scheme-or-reference": {
       "if": {
+        "type": "object",
         "required": [
           "$ref"
         ]
@@ -1302,6 +1347,7 @@
       }
     },
     "security-requirement": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#security-requirement-object",
       "type": "object",
       "additionalProperties": {
         "type": "array",
@@ -1311,6 +1357,7 @@
       }
     },
     "specification-extensions": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#specification-extensions",
       "patternProperties": {
         "^x-": true
       }
@@ -1325,10 +1372,6 @@
           }
         }
       }
-    },
-    "uri": {
-      "type": "string",
-      "format": "uri"
     },
     "map-of-strings": {
       "type": "object",

--- a/schemas/openapi-v3.1.yaml
+++ b/schemas/openapi-v3.1.yaml
@@ -1,4 +1,4 @@
-$id: 'https://spec.openapis.org/oas/3.1/schema/2021-03-02'
+$id: 'https://spec.openapis.org/oas/3.1/schema/2021-09-28'
 $schema: 'https://json-schema.org/draft/2020-12/schema'
 
 type: object
@@ -9,10 +9,13 @@ properties:
   info:
     $ref: '#/$defs/info'
   jsonSchemaDialect:
-    $ref: '#/$defs/uri'
+    type: string
+    format: uri
     default: 'https://spec.openapis.org/oas/3.1/dialect/base'
   servers:
-    $ref: '#/$defs/server'
+    type: array
+    items:
+      $ref: '#/$defs/server'
   paths:
     $ref: '#/$defs/paths'
   webhooks:
@@ -46,6 +49,7 @@ unevaluatedProperties: false
 
 $defs:
   info:
+    $comment: https://spec.openapis.org/oas/v3.1.0#info-object
     type: object
     properties:
       title:
@@ -69,6 +73,7 @@ $defs:
     unevaluatedProperties: false
 
   contact:
+    $comment: https://spec.openapis.org/oas/v3.1.0#contact-object
     type: object
     properties:
       name:
@@ -81,6 +86,7 @@ $defs:
     unevaluatedProperties: false
 
   license:
+    $comment: https://spec.openapis.org/oas/v3.1.0#license-object
     type: object
     properties:
       name:
@@ -88,7 +94,8 @@ $defs:
       identifier:
         type: string
       url:
-        $ref: '#/$defs/uri'
+        type: string
+        format: uri
     required:
       - name
     oneOf:
@@ -100,10 +107,12 @@ $defs:
     unevaluatedProperties: false
 
   server:
+    $comment: https://spec.openapis.org/oas/v3.1.0#server-object
     type: object
     properties:
       url:
-        $ref: '#/$defs/uri'
+        type: string
+        format: uri-reference
       description:
         type: string
       variables:
@@ -116,6 +125,7 @@ $defs:
     unevaluatedProperties: false
 
   server-variable:
+    $comment: https://spec.openapis.org/oas/v3.1.0#server-variable-object
     type: object
     properties:
       enum:
@@ -125,7 +135,7 @@ $defs:
         minItems: 1
       default:
         type: string
-      descriptions:
+      description:
         type: string
     required:
       - default
@@ -133,6 +143,7 @@ $defs:
     unevaluatedProperties: false
 
   components:
+    $comment: https://spec.openapis.org/oas/v3.1.0#components-object
     type: object
     properties:
       schemas:
@@ -184,6 +195,7 @@ $defs:
     unevaluatedProperties: false
 
   paths:
+    $comment: https://spec.openapis.org/oas/v3.1.0#paths-object
     type: object
     patternProperties:
       '^/':
@@ -192,6 +204,7 @@ $defs:
     unevaluatedProperties: false
 
   path-item:
+    $comment: https://spec.openapis.org/oas/v3.1.0#path-item-object
     type: object
     properties:
       summary:
@@ -207,13 +220,14 @@ $defs:
         items:
           $ref: '#/$defs/parameter-or-reference'
     patternProperties:
-      '^(get|post|delete|options|head|patch|trace)$':
+      '^(get|put|post|delete|options|head|patch|trace)$':
         $ref: '#/$defs/operation'
     $ref: '#/$defs/specification-extensions'
     unevaluatedProperties: false
 
   path-item-or-reference:
     if:
+      type: object
       required:
         - $ref
     then:
@@ -222,6 +236,7 @@ $defs:
       $ref: '#/$defs/path-item'
 
   operation:
+    $comment: https://spec.openapis.org/oas/v3.1.0#operation-object
     type: object
     properties:
       tags:
@@ -263,18 +278,21 @@ $defs:
     unevaluatedProperties: false
 
   external-documentation:
+    $comment: https://spec.openapis.org/oas/v3.1.0#external-documentation-object
     type: object
     properties:
       description:
         type: string
       url:
-        $ref: '#/$defs/uri'
+        type: string
+        format: uri
     required:
       - url
     $ref: '#/$defs/specification-extensions'
     unevaluatedProperties: false
 
   parameter:
+    $comment: https://spec.openapis.org/oas/v3.1.0#parameter-object
     type: object
     properties:
       name:
@@ -300,7 +318,10 @@ $defs:
         $dynamicRef: '#meta'
       content:
         $ref: '#/$defs/content'
+        minProperties: 1
+        maxProperties: 1
     required:
+      - name
       - in
     oneOf:
       - required:
@@ -335,6 +356,8 @@ $defs:
                 - in
             then:
               properties:
+                name:
+                  pattern: '[^/#?]+$'
                 style:
                   default: simple
                   enum:
@@ -357,8 +380,7 @@ $defs:
               properties:
                 style:
                   default: simple
-                  enum:
-                    - simple
+                  const: simple
 
           styles-for-query:
             if:
@@ -388,8 +410,7 @@ $defs:
               properties:
                 style:
                   default: form
-                  enum:
-                    - form
+                  const: form
 
           styles-for-form:
             if:
@@ -412,6 +433,7 @@ $defs:
 
   parameter-or-reference:
     if:
+      type: object
       required:
         - $ref
     then:
@@ -420,6 +442,7 @@ $defs:
       $ref: '#/$defs/parameter'
 
   request-body:
+    $comment: https://spec.openapis.org/oas/v3.1.0#request-body-object
     type: object
     properties:
       description:
@@ -436,6 +459,7 @@ $defs:
 
   request-body-or-reference:
     if:
+      type: object
       required:
         - $ref
     then:
@@ -444,6 +468,7 @@ $defs:
       $ref: '#/$defs/request-body'
 
   content:
+    $comment: https://spec.openapis.org/oas/v3.1.0#fixed-fields-10
     type: object
     additionalProperties:
       $ref: '#/$defs/media-type'
@@ -451,6 +476,7 @@ $defs:
       format: media-range
 
   media-type:
+    $comment: https://spec.openapis.org/oas/v3.1.0#media-type-object
     type: object
     properties:
       schema:
@@ -465,6 +491,7 @@ $defs:
     unevaluatedProperties: false
 
   encoding:
+    $comment: https://spec.openapis.org/oas/v3.1.0#encoding-object
     type: object
     properties:
       contentType:
@@ -509,17 +536,19 @@ $defs:
               default: false
 
   responses:
+    $comment: https://spec.openapis.org/oas/v3.1.0#responses-object
     type: object
     properties:
       default:
         $ref: '#/$defs/response-or-reference'
     patternProperties:
-      '^[1-5][0-9X]{2}$':
+      '^[1-5](?:[0-9]{2}|XX)$':
         $ref: '#/$defs/response-or-reference'
     $ref: '#/$defs/specification-extensions'
     unevaluatedProperties: false
 
   response:
+    $comment: https://spec.openapis.org/oas/v3.1.0#response-object
     type: object
     properties:
       description:
@@ -541,6 +570,7 @@ $defs:
 
   response-or-reference:
     if:
+      type: object
       required:
         - $ref
     then:
@@ -549,6 +579,7 @@ $defs:
       $ref: '#/$defs/response'
 
   callbacks:
+    $comment: https://spec.openapis.org/oas/v3.1.0#callback-object
     type: object
     $ref: '#/$defs/specification-extensions'
     additionalProperties:
@@ -556,6 +587,7 @@ $defs:
 
   callbacks-or-reference:
     if:
+      type: object
       required:
         - $ref
     then:
@@ -564,6 +596,7 @@ $defs:
       $ref: '#/$defs/callbacks'
 
   example:
+    $comment: https://spec.openapis.org/oas/v3.1.0#example-object
     type: object
     properties:
       summary:
@@ -572,12 +605,14 @@ $defs:
         type: string
       value: true
       externalValue:
-        $ref: '#/$defs/uri'
+        type: string
+        format: uri
     $ref: '#/$defs/specification-extensions'
     unevaluatedProperties: false
 
   example-or-reference:
     if:
+      type: object
       required:
         - $ref
     then:
@@ -586,10 +621,12 @@ $defs:
       $ref: '#/$defs/example'
 
   link:
+    $comment: https://spec.openapis.org/oas/v3.1.0#link-object
     type: object
     properties:
       operationRef:
-        $ref: '#/$defs/uri'
+        type: string
+        format: uri-reference
       operationId: true
       parameters:
         $ref: '#/$defs/map-of-strings'
@@ -608,6 +645,7 @@ $defs:
 
   link-or-reference:
     if:
+      type: object
       required:
         - $ref
     then:
@@ -616,6 +654,7 @@ $defs:
       $ref: '#/$defs/link'
 
   header:
+    $comment: https://spec.openapis.org/oas/v3.1.0#header-object
     type: object
     properties:
       description:
@@ -626,34 +665,33 @@ $defs:
       deprecated:
         default: false
         type: boolean
-      allowEmptyValue:
-        default: false
-        type: boolean
+      schema:
+        $dynamicRef: '#meta'
+      content:
+        $ref: '#/$defs/content'
+        minProperties: 1
+        maxProperties: 1
+    oneOf:
+      - required:
+        - schema
+      - required:
+        - content
     dependentSchemas:
       schema:
         properties:
           style:
             default: simple
-            enum:
-              - simple
+            const: simple
           explode:
             default: false
             type: boolean
-          allowReserved:
-            default: false
-            type: boolean
-          schema:
-            $dynamicRef: '#meta'
         $ref: '#/$defs/examples'
-      content:
-        properties:
-          content:
-            $ref: '#/$defs/content'
     $ref: '#/$defs/specification-extensions'
     unevaluatedProperties: false
 
   header-or-reference:
     if:
+      type: object
       required:
         - $ref
     then:
@@ -662,6 +700,7 @@ $defs:
       $ref: '#/$defs/header'
 
   tag:
+    $comment: https://spec.openapis.org/oas/v3.1.0#tag-object
     type: object
     properties:
       name:
@@ -676,10 +715,12 @@ $defs:
     unevaluatedProperties: false
 
   reference:
+    $comment: https://spec.openapis.org/oas/v3.1.0#reference-object
     type: object
     properties:
       $ref:
-        $ref: '#/$defs/uri'
+        type: string
+        format: uri-reference
       summary:
         type: string
       description:
@@ -687,12 +728,14 @@ $defs:
     unevaluatedProperties: false
 
   schema:
+    $comment: https://spec.openapis.org/oas/v3.1.0#schema-object
     $dynamicAnchor: meta
     type:
       - object
       - boolean
 
   security-scheme:
+    $comment: https://spec.openapis.org/oas/v3.1.0#security-scheme-object
     type: object
     properties:
       type:
@@ -756,7 +799,8 @@ $defs:
             type:
               const: http
             scheme:
-              const: bearer
+              type: string
+              pattern: ^[Bb][Ee][Aa][Rr][Ee][Rr]$
           required:
             - type
             - scheme
@@ -764,8 +808,6 @@ $defs:
           properties:
             bearerFormat:
               type: string
-          required:
-            - scheme
 
       type-oauth2:
         if:
@@ -791,12 +833,14 @@ $defs:
         then:
           properties:
             openIdConnectUrl:
-              $ref: '#/$defs/uri'
+              type: string
+              format: uri
           required:
             - openIdConnectUrl
 
   security-scheme-or-reference:
     if:
+      type: object
       required:
         - $ref
     then:
@@ -883,6 +927,7 @@ $defs:
         unevaluatedProperties: false
 
   security-requirement:
+    $comment: https://spec.openapis.org/oas/v3.1.0#security-requirement-object
     type: object
     additionalProperties:
       type: array
@@ -890,6 +935,7 @@ $defs:
         type: string
 
   specification-extensions:
+    $comment: https://spec.openapis.org/oas/v3.1.0#specification-extensions
     patternProperties:
       '^x-': true
 
@@ -900,10 +946,6 @@ $defs:
         type: object
         additionalProperties:
           $ref: '#/$defs/example-or-reference'
-
-  uri:
-    type: string
-    format: uri
 
   map-of-strings:
     type: object


### PR DESCRIPTION
Currently committed schema uses pre-release version with incorrect value for servers field

Updates #128 