### PR TITLE
Flags for json_encode() in \cebe\openapi\Writer::writeToJson()

### DIFF
--- a/src/Writer.php
+++ b/src/Writer.php
@@ -20,7 +20,7 @@ class Writer
     /**
      * Convert OpenAPI spec object to JSON data.
      * @param SpecObjectInterface|OpenApi $object the OpenApi object instance.
-     * @param int $flags json_encode() flags
+     * @param int $flags json_encode() flags. Parameter available since version 1.7.0.
      * @return string JSON string.
      */
     public static function writeToJson(SpecObjectInterface $object, int $flags = JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE): string

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -20,11 +20,12 @@ class Writer
     /**
      * Convert OpenAPI spec object to JSON data.
      * @param SpecObjectInterface|OpenApi $object the OpenApi object instance.
+     * @param int $flags json_encode() flags
      * @return string JSON string.
      */
-    public static function writeToJson(SpecObjectInterface $object): string
+    public static function writeToJson(SpecObjectInterface $object, int $flags = JSON_PRETTY_PRINT): string
     {
-        return json_encode($object->getSerializableData(), JSON_PRETTY_PRINT);
+        return json_encode($object->getSerializableData(), $flags);
     }
 
     /**

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -23,7 +23,7 @@ class Writer
      * @param int $flags json_encode() flags
      * @return string JSON string.
      */
-    public static function writeToJson(SpecObjectInterface $object, int $flags = JSON_PRETTY_PRINT): string
+    public static function writeToJson(SpecObjectInterface $object, int $flags = JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE): string
     {
         return json_encode($object->getSerializableData(), $flags);
     }


### PR DESCRIPTION
Added opportunity for use additional flags for json_encode() function in \cebe\openapi\Writer::writeToJson().
Example JSON_UNESCAPED_UNICODE for non-latin chars.