### PR TITLE
Php 8.1 compatibility

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -19,6 +19,7 @@ jobs:
           - "7.3"
           - "7.4"
           - "8.0"
+          - "8.1"
         dependencies:
           - "lowest"
           - "highest"
@@ -47,6 +48,8 @@ jobs:
             symfony-yaml: '^6'
           # symfony/yaml v3.4 is not compatible with PHP 8.0 but has no upper-bound, so it installs on it
           - php: '8.0'
+            symfony-yaml: '^3.4'
+          - php: '8.1'
             symfony-yaml: '^3.4'
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -65,7 +65,11 @@ jobs:
           tools: composer:v2
 
       - name: Require specific symfony/yaml version
-        run: "composer require symfony/yaml:'${{ matrix.symfony-yaml }}' --prefer-dist --no-interaction --ansi --no-install"
+        run: "composer require symfony/yaml:'${{ matrix.symfony-yaml }}' --no-interaction --ansi --no-install"
+
+      - name: Require newer phpunit/phpunit version
+        run: "composer require phpunit/phpunit '^9.5' --dev --no-interaction --ansi --no-install"
+        if: matrix.php == '8.1'
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v2"

--- a/src/json/JsonReference.php
+++ b/src/json/JsonReference.php
@@ -126,6 +126,7 @@ final class JsonReference implements JsonSerializable
      * @return mixed data which can be serialized by <b>json_encode</b>,
      * which is a value of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return (object)['$ref' => $this->getReference()];

--- a/src/json/JsonReference.php
+++ b/src/json/JsonReference.php
@@ -127,7 +127,7 @@ final class JsonReference implements JsonSerializable
      * which is a value of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize() //: mixed
     {
         return (object)['$ref' => $this->getReference()];
     }

--- a/src/spec/Paths.php
+++ b/src/spec/Paths.php
@@ -183,6 +183,7 @@ class Paths implements SpecObjectInterface, DocumentContextInterface, ArrayAcces
      * @return boolean true on success or false on failure.
      * The return value will be casted to boolean if non-boolean was returned.
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return $this->hasPath($offset);
@@ -194,6 +195,7 @@ class Paths implements SpecObjectInterface, DocumentContextInterface, ArrayAcces
      * @param mixed $offset The offset to retrieve.
      * @return PathItem Can return all value types.
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->getPath($offset);
@@ -205,6 +207,7 @@ class Paths implements SpecObjectInterface, DocumentContextInterface, ArrayAcces
      * @param mixed $offset The offset to assign the value to.
      * @param mixed $value The value to set.
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->addPath($offset, $value);
@@ -215,6 +218,7 @@ class Paths implements SpecObjectInterface, DocumentContextInterface, ArrayAcces
      * @link http://php.net/manual/en/arrayaccess.offsetunset.php
      * @param mixed $offset The offset to unset.
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         $this->removePath($offset);
@@ -226,6 +230,7 @@ class Paths implements SpecObjectInterface, DocumentContextInterface, ArrayAcces
      * @return int The custom count as an integer.
      * The return value is cast to an integer.
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->_paths);
@@ -236,6 +241,7 @@ class Paths implements SpecObjectInterface, DocumentContextInterface, ArrayAcces
      * @link http://php.net/manual/en/iteratoraggregate.getiterator.php
      * @return Traversable An instance of an object implementing <b>Iterator</b> or <b>Traversable</b>
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->_paths);

--- a/src/spec/Paths.php
+++ b/src/spec/Paths.php
@@ -183,8 +183,7 @@ class Paths implements SpecObjectInterface, DocumentContextInterface, ArrayAcces
      * @return boolean true on success or false on failure.
      * The return value will be casted to boolean if non-boolean was returned.
      */
-    #[\ReturnTypeWillChange]
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return $this->hasPath($offset);
     }
@@ -196,7 +195,7 @@ class Paths implements SpecObjectInterface, DocumentContextInterface, ArrayAcces
      * @return PathItem Can return all value types.
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet($offset) //: mixed
     {
         return $this->getPath($offset);
     }
@@ -207,8 +206,7 @@ class Paths implements SpecObjectInterface, DocumentContextInterface, ArrayAcces
      * @param mixed $offset The offset to assign the value to.
      * @param mixed $value The value to set.
      */
-    #[\ReturnTypeWillChange]
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->addPath($offset, $value);
     }
@@ -218,8 +216,7 @@ class Paths implements SpecObjectInterface, DocumentContextInterface, ArrayAcces
      * @link http://php.net/manual/en/arrayaccess.offsetunset.php
      * @param mixed $offset The offset to unset.
      */
-    #[\ReturnTypeWillChange]
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         $this->removePath($offset);
     }
@@ -230,8 +227,7 @@ class Paths implements SpecObjectInterface, DocumentContextInterface, ArrayAcces
      * @return int The custom count as an integer.
      * The return value is cast to an integer.
      */
-    #[\ReturnTypeWillChange]
-    public function count()
+    public function count(): int
     {
         return count($this->_paths);
     }
@@ -241,8 +237,7 @@ class Paths implements SpecObjectInterface, DocumentContextInterface, ArrayAcces
      * @link http://php.net/manual/en/iteratoraggregate.getiterator.php
      * @return Traversable An instance of an object implementing <b>Iterator</b> or <b>Traversable</b>
      */
-    #[\ReturnTypeWillChange]
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->_paths);
     }

--- a/src/spec/Responses.php
+++ b/src/spec/Responses.php
@@ -173,6 +173,7 @@ class Responses implements SpecObjectInterface, DocumentContextInterface, ArrayA
      * @return boolean true on success or false on failure.
      * The return value will be casted to boolean if non-boolean was returned.
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return $this->hasResponse($offset);
@@ -184,6 +185,7 @@ class Responses implements SpecObjectInterface, DocumentContextInterface, ArrayA
      * @param mixed $offset The offset to retrieve.
      * @return mixed Can return all value types.
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->getResponse($offset);
@@ -195,6 +197,7 @@ class Responses implements SpecObjectInterface, DocumentContextInterface, ArrayA
      * @param mixed $offset The offset to assign the value to.
      * @param mixed $value The value to set.
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->addResponse($offset, $value);
@@ -205,6 +208,7 @@ class Responses implements SpecObjectInterface, DocumentContextInterface, ArrayA
      * @link http://php.net/manual/en/arrayaccess.offsetunset.php
      * @param mixed $offset The offset to unset.
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         $this->removeResponse($offset);
@@ -216,6 +220,7 @@ class Responses implements SpecObjectInterface, DocumentContextInterface, ArrayA
      * @return int The custom count as an integer.
      * The return value is cast to an integer.
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->_responses);
@@ -226,6 +231,7 @@ class Responses implements SpecObjectInterface, DocumentContextInterface, ArrayA
      * @link http://php.net/manual/en/iteratoraggregate.getiterator.php
      * @return Traversable An instance of an object implementing <b>Iterator</b> or <b>Traversable</b>
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->_responses);

--- a/src/spec/Responses.php
+++ b/src/spec/Responses.php
@@ -173,8 +173,7 @@ class Responses implements SpecObjectInterface, DocumentContextInterface, ArrayA
      * @return boolean true on success or false on failure.
      * The return value will be casted to boolean if non-boolean was returned.
      */
-    #[\ReturnTypeWillChange]
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return $this->hasResponse($offset);
     }
@@ -186,7 +185,7 @@ class Responses implements SpecObjectInterface, DocumentContextInterface, ArrayA
      * @return mixed Can return all value types.
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet($offset) //: mixed
     {
         return $this->getResponse($offset);
     }
@@ -197,8 +196,7 @@ class Responses implements SpecObjectInterface, DocumentContextInterface, ArrayA
      * @param mixed $offset The offset to assign the value to.
      * @param mixed $value The value to set.
      */
-    #[\ReturnTypeWillChange]
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->addResponse($offset, $value);
     }
@@ -208,8 +206,7 @@ class Responses implements SpecObjectInterface, DocumentContextInterface, ArrayA
      * @link http://php.net/manual/en/arrayaccess.offsetunset.php
      * @param mixed $offset The offset to unset.
      */
-    #[\ReturnTypeWillChange]
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         $this->removeResponse($offset);
     }
@@ -220,8 +217,7 @@ class Responses implements SpecObjectInterface, DocumentContextInterface, ArrayA
      * @return int The custom count as an integer.
      * The return value is cast to an integer.
      */
-    #[\ReturnTypeWillChange]
-    public function count()
+    public function count(): int
     {
         return count($this->_responses);
     }
@@ -231,8 +227,7 @@ class Responses implements SpecObjectInterface, DocumentContextInterface, ArrayA
      * @link http://php.net/manual/en/iteratoraggregate.getiterator.php
      * @return Traversable An instance of an object implementing <b>Iterator</b> or <b>Traversable</b>
      */
-    #[\ReturnTypeWillChange]
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->_responses);
     }


### PR DESCRIPTION
this includes:

- https://github.com/cebe/php-openapi/pull/123
- https://github.com/OM4/php-openapi/pull/3
- 495f3efe6524be45c67be5b733c1d082839fc4d5 which replaces `#[\ReturnTypeWillChange]` annotation in cases where return type is compatible with PHP 7 (not `mixed` type is used)

replaces:

- #135