### PR TITLE
Implement JsonSerializable so OpenApi instance can be serialized using json_encode()

### DIFF
--- a/src/SpecBaseObject.php
+++ b/src/SpecBaseObject.php
@@ -13,6 +13,7 @@ use cebe\openapi\json\JsonPointer;
 use cebe\openapi\json\JsonReference;
 use cebe\openapi\spec\Reference;
 use cebe\openapi\spec\Type;
+use \JsonSerializable;
 
 /**
  * Base class for all spec objects.
@@ -20,7 +21,7 @@ use cebe\openapi\spec\Type;
  * Implements property management and validation basics.
  *
  */
-abstract class SpecBaseObject implements SpecObjectInterface, DocumentContextInterface
+abstract class SpecBaseObject implements SpecObjectInterface, DocumentContextInterface, JsonSerializable
 {
     private $_properties = [];
     private $_errors = [];
@@ -524,5 +525,9 @@ abstract class SpecBaseObject implements SpecObjectInterface, DocumentContextInt
             $extensions[$propertyKey] = $extension;
         }
         return $extensions;
+    }
+
+    public function jsonSerialize() {
+        return $this->getSerializableData();
     }
 }

--- a/src/spec/OpenApi.php
+++ b/src/spec/OpenApi.php
@@ -9,7 +9,6 @@ namespace cebe\openapi\spec;
 
 use cebe\openapi\exceptions\TypeErrorException;
 use cebe\openapi\SpecBaseObject;
-use cebe\openapi\Writer;
 use \JsonSerializable;
 
 /**
@@ -83,6 +82,6 @@ class OpenApi extends SpecBaseObject implements JsonSerializable
     }
 
     public function jsonSerialize() {
-        return Writer::writeToJson($this);
+        return $this->getSerializableData();
     }
 }

--- a/src/spec/OpenApi.php
+++ b/src/spec/OpenApi.php
@@ -9,7 +9,6 @@ namespace cebe\openapi\spec;
 
 use cebe\openapi\exceptions\TypeErrorException;
 use cebe\openapi\SpecBaseObject;
-use \JsonSerializable;
 
 /**
  * This is the root document object of the OpenAPI document.
@@ -26,7 +25,7 @@ use \JsonSerializable;
  * @property ExternalDocumentation|null $externalDocs
  *
  */
-class OpenApi extends SpecBaseObject implements JsonSerializable
+class OpenApi extends SpecBaseObject
 {
     /**
      * @return array array of attributes available in this object.
@@ -79,9 +78,5 @@ class OpenApi extends SpecBaseObject implements JsonSerializable
         if (!empty($this->openapi) && !preg_match('/^3\.0\.\d+(-rc\d)?$/i', $this->openapi)) {
             $this->addError('Unsupported openapi version: ' . $this->openapi);
         }
-    }
-
-    public function jsonSerialize() {
-        return $this->getSerializableData();
     }
 }

--- a/src/spec/OpenApi.php
+++ b/src/spec/OpenApi.php
@@ -9,6 +9,8 @@ namespace cebe\openapi\spec;
 
 use cebe\openapi\exceptions\TypeErrorException;
 use cebe\openapi\SpecBaseObject;
+use cebe\openapi\Writer;
+use \JsonSerializable;
 
 /**
  * This is the root document object of the OpenAPI document.
@@ -25,7 +27,7 @@ use cebe\openapi\SpecBaseObject;
  * @property ExternalDocumentation|null $externalDocs
  *
  */
-class OpenApi extends SpecBaseObject
+class OpenApi extends SpecBaseObject implements JsonSerializable
 {
     /**
      * @return array array of attributes available in this object.
@@ -78,5 +80,9 @@ class OpenApi extends SpecBaseObject
         if (!empty($this->openapi) && !preg_match('/^3\.0\.\d+(-rc\d)?$/i', $this->openapi)) {
             $this->addError('Unsupported openapi version: ' . $this->openapi);
         }
+    }
+
+    public function jsonSerialize() {
+        return Writer::writeToJson($this);
     }
 }


### PR DESCRIPTION
Allows the ability to serialize `OpenApi` instance like this:

```php
$openApi = Reader::readFromYaml($yaml);
$json = json_encode($openApi);
```