### PR TITLE
Do not assume Reference when Schema is requested

### DIFF
--- a/src/SpecBaseObject.php
+++ b/src/SpecBaseObject.php
@@ -12,6 +12,7 @@ use cebe\openapi\exceptions\UnknownPropertyException;
 use cebe\openapi\json\JsonPointer;
 use cebe\openapi\json\JsonReference;
 use cebe\openapi\spec\Reference;
+use cebe\openapi\spec\Schema;
 use cebe\openapi\spec\Type;
 
 /**
@@ -153,7 +154,7 @@ abstract class SpecBaseObject implements SpecObjectInterface, DocumentContextInt
             return $data;
         }
 
-        if (is_array($data) && isset($data['$ref'])) {
+        if (is_array($data) && isset($data['$ref']) && $type !== Schema::class) {
             return new Reference($data, $type);
         }
 


### PR DESCRIPTION
I have a problem with the following spec:
```json
{
  "type": "object",
  "additionalProperties": {
    "nullable": true,
    "$ref": "#/components/schemas/Reference"
  }
}
```
The problem is that the code assumes it is a `Reference` when `$ref` is set, but that is actually not true in this case since it is a proper `Schema`.


Dirty fix I tried before properly debugging this: https://github.com/cebe/php-openapi/pull/184