### PR TITLE
Add the 'null' type

### DIFF
--- a/src/spec/Type.php
+++ b/src/spec/Type.php
@@ -21,6 +21,7 @@ class Type
     const BOOLEAN = 'boolean';
     const OBJECT = 'object';
     const ARRAY = 'array';
+    const NULL = 'null';
 
     /**
      * Indicate whether a type is a scalar type, i.e. not an array or object.


### PR DESCRIPTION
Since OAS 3.1, the 'null' has been promoted to a type. This is reflected in 3rd party GUIs such as stoplight and the community is beginning to adopt it.

It looks like it's no longer recommended to use `nullable: true` notation.

https://www.openapis.org/blog/2021/02/16/migrating-from-openapi-3-0-to-3-1-0