### PR TITLE
Add gitattributes to reduce installed size of the project

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+/.github             export-ignore
+/tests               export-ignore
+.gitattributes       export-ignore
+.gitignore           export-ignore
+.php_cs.dist         export-ignore
+docker-compose.yml   export-ignore
+Makefile             export-ignore
+package.json         export-ignore
+phpunit.xml.dist     export-ignore
+yarn.lock            export-ignore


### PR DESCRIPTION
This should reduce the size of this package when downloaded to vendor directories.

I don't think that any of these files are required for this package to be used, mostly helpful when developing.

(see https://php.watch/articles/composer-gitattributes for more info)

Finally implements - https://github.com/cebe/php-openapi/issues/157#issuecomment-1105424823 also so people's security tools post-install won't moan.